### PR TITLE
Allow configuring Selenium Grid host

### DIFF
--- a/src/main/java/bc/bfi/youtuber_about/ChromeDownloader.java
+++ b/src/main/java/bc/bfi/youtuber_about/ChromeDownloader.java
@@ -21,8 +21,8 @@ public class ChromeDownloader {
     private static final Logger LOGGER = Logger.getLogger(ChromeDownloader.class.getName());
     private final PageContentExtractor extractor = new PageContentExtractor();
 
-    public String download(String url) {
-        WebDriver driver = createDriver();
+    public String download(String url, String gridHost) {
+        WebDriver driver = createDriver(gridHost);
         
         // Load page.
         System.out.println("Downloading page " + url);
@@ -86,7 +86,7 @@ public class ChromeDownloader {
         }
     }
 
-    protected WebDriver createDriver() {
+    protected WebDriver createDriver(String gridHost) {
         ChromeOptions options = new ChromeOptions();
         //options.addArguments("--remote-allow-origins=*");
         //options.addArguments("--proxy-server=socks5://3.85.180.106:1080");
@@ -98,12 +98,12 @@ public class ChromeDownloader {
         options.addArguments("--no-sandbox");
         options.addArguments("--disable-blink-features");
 
-        return connectRemote(options);
+        return connectRemote(gridHost, options);
     }
 
-    private WebDriver connectRemote(ChromeOptions options) {
+    protected WebDriver connectRemote(String gridHost, ChromeOptions options) {
         try {
-            URL url = new URL("http://localhost:4444/wd/hub");
+            URL url = new URL("http://" + gridHost + ":4444/wd/hub");
             return new RemoteWebDriver(url, options);
         } catch (MalformedURLException ex) {
             throw new RuntimeException(ex);

--- a/src/main/java/bc/bfi/youtuber_about/ScrapeServlet.java
+++ b/src/main/java/bc/bfi/youtuber_about/ScrapeServlet.java
@@ -31,6 +31,11 @@ public class ScrapeServlet extends HttpServlet {
             return;
         }
 
+        String gridHost = req.getParameter("gridHost");
+        if (gridHost == null || gridHost.isEmpty()) {
+            gridHost = "localhost";
+        }
+
         if (base.exists(channelId)) {
             resp.setContentType("text/plain");
             PrintWriter writer = resp.getWriter();
@@ -47,7 +52,7 @@ public class ScrapeServlet extends HttpServlet {
         System.out.println("-------------------------------------");
         System.out.println("Scrape: " + url);
 
-        String webPage = downloader.download(url);
+        String webPage = downloader.download(url, gridHost);
         ChannelAbout channel = parser.parse(url, webPage);
         base.add(channel);
 

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -17,6 +17,10 @@
 
         <form id="scrapeForm">
             <div class="form-group">
+                <label for="gridHost">Selenium Grid Host:</label>
+                <input id="gridHost" name="gridHost" class="form-control" type="text" placeholder="localhost" />
+            </div>
+            <div class="form-group">
                 <label for="queries">Channel names:</label>
                 <textarea id="queries" name="queries" class="form-control" rows="5" placeholder="One channel name per line"></textarea>
             </div>
@@ -31,7 +35,43 @@
         </form>
 
         <script>
+            var dbPromise = new Promise(function(resolve, reject) {
+                var request = indexedDB.open('selenium-grid', 1);
+                request.onupgradeneeded = function(event) {
+                    var db = event.target.result;
+                    db.createObjectStore('config', { keyPath: 'id' });
+                };
+                request.onsuccess = function(event) {
+                    resolve(event.target.result);
+                };
+                request.onerror = function(event) {
+                    reject(event.target.error);
+                };
+            });
+
+            function loadGridHost() {
+                dbPromise.then(function(db) {
+                    var tx = db.transaction('config', 'readonly');
+                    var store = tx.objectStore('config');
+                    var req = store.get('gridHost');
+                    req.onsuccess = function() {
+                        if (req.result) {
+                            $('#gridHost').val(req.result.value);
+                        }
+                    };
+                });
+            }
+
+            function saveGridHost(value) {
+                dbPromise.then(function(db) {
+                    var tx = db.transaction('config', 'readwrite');
+                    var store = tx.objectStore('config');
+                    store.put({ id: 'gridHost', value: value });
+                });
+            }
+
             $(function() {
+                loadGridHost();
                 $('#stopBtn').on('click', function() {
                     if (confirm('Stop scraping process?')) {
                         console.log('Stopping...');
@@ -52,6 +92,9 @@
                         return;
                     }
 
+                    var host = $('#gridHost').val().trim() || 'localhost';
+                    saveGridHost(host);
+
                     $('#progressBar').css('width', '0%').attr('aria-valuenow', 0);
                     $('#progressLog').empty();
                     $('#startBtn').prop('disabled', true);
@@ -69,7 +112,7 @@
                         $.ajax({
                             url: 'scrape',
                             method: 'POST',
-                            data: { queries: q.substring('https://youtube.com/'.length) },
+                            data: { queries: q.substring('https://youtube.com/'.length), gridHost: host },
                             success: function() {
                                 console.log('Processed: ' + q);
                             },

--- a/src/test/java/bc/bfi/youtuber_about/ChromeDownloaderTest.java
+++ b/src/test/java/bc/bfi/youtuber_about/ChromeDownloaderTest.java
@@ -16,12 +16,12 @@ public class ChromeDownloaderTest {
     public void createDriverShouldUseRemote() {
         final WebDriver remote = mock(WebDriver.class);
         ChromeDownloader downloader = new ChromeDownloader() {
-            protected WebDriver connectRemote(ChromeOptions options) {
+            protected WebDriver connectRemote(String gridHost, ChromeOptions options) {
                 return remote;
             }
         };
 
-        WebDriver driver = downloader.createDriver();
+        WebDriver driver = downloader.createDriver("localhost");
 
         assertThat(driver, sameInstance(remote));
     }

--- a/src/test/java/bc/bfi/youtuber_about/ScrapeServletTest.java
+++ b/src/test/java/bc/bfi/youtuber_about/ScrapeServletTest.java
@@ -26,6 +26,7 @@ public class ScrapeServletTest {
         HttpServletRequest req = mock(HttpServletRequest.class);
         HttpServletResponse resp = mock(HttpServletResponse.class);
         when(req.getParameter("queries")).thenReturn("test-domain");
+        when(req.getParameter("gridHost")).thenReturn("localhost");
 
         StringWriter out = new StringWriter();
         when(resp.getWriter()).thenReturn(new PrintWriter(out));
@@ -35,7 +36,7 @@ public class ScrapeServletTest {
         Base base = mock(Base.class);
         when(base.exists("test-domain")).thenReturn(false);
 
-        when(downloader.download("test-domain")).thenReturn("page");
+        when(downloader.download("test-domain", "localhost")).thenReturn("page");
         ChannelAbout about = new ChannelAbout("test-domain");
         when(parser.parse("test-domain", "page")).thenReturn(about);
 
@@ -43,7 +44,7 @@ public class ScrapeServletTest {
         servlet.doPost(req, resp);
 
         verify(base).exists("test-domain");
-        verify(downloader).download("test-domain");
+        verify(downloader).download("test-domain", "localhost");
         verify(parser).parse("test-domain", "page");
         verify(base).add(about);
         assertThat(out.toString(), equalTo("Scraped: test-domain"));
@@ -68,7 +69,7 @@ public class ScrapeServletTest {
         servlet.doPost(req, resp);
 
         verify(base).exists("test-domain");
-        verify(downloader, never()).download(anyString());
+        verify(downloader, never()).download(anyString(), anyString());
         verify(parser, never()).parse(anyString(), anyString());
         verify(base, never()).add(any(ChannelAbout.class));
         assertThat(out.toString(), equalTo("Skipped: test-domain"));


### PR DESCRIPTION
## Summary
- add Selenium Grid host field to index page and persist via IndexedDB
- pass provided host to backend and use it when creating the remote WebDriver
- update unit tests for configurable host

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6890eaf2ce0c832b9ddc384147c8545d